### PR TITLE
Fix: Add default image and fallback search for recipe images

### DIFF
--- a/src/features/recipes/components/ImagePreviewModal.tsx
+++ b/src/features/recipes/components/ImagePreviewModal.tsx
@@ -1,0 +1,120 @@
+interface ImagePreviewModalProps {
+  isOpen: boolean
+  imageUrl: string | null
+  dishName: string
+  onConfirm: (useImage: boolean) => void
+  onClose: () => void
+}
+
+/**
+ * レシピ画像のプレビュー・確認モーダル
+ *
+ * AI抽出後にUnsplashから取得した画像をユーザーに確認してもらい、
+ * 使用するかどうかを選択できるようにする。
+ */
+export function ImagePreviewModal({
+  isOpen,
+  imageUrl,
+  dishName,
+  onConfirm,
+  onClose,
+}: ImagePreviewModalProps) {
+  if (!isOpen) return null
+
+  const handleUseImage = () => {
+    onConfirm(true)
+  }
+
+  const handleSkipImage = () => {
+    onConfirm(false)
+  }
+
+  return (
+    <>
+      {/* オーバーレイ */}
+      <div
+        className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+        onClick={onClose}
+      >
+        {/* モーダルコンテンツ */}
+        <div
+          className="bg-notebook-card rounded-card shadow-card-hover border border-notebook-border max-w-2xl w-full max-h-[90vh] overflow-y-auto"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* 紙のテクスチャ */}
+          <div className="absolute inset-0 bg-paper-texture opacity-30 pointer-events-none z-texture rounded-card" />
+
+          {/* ヘッダー */}
+          <div className="relative z-content p-6 border-b border-notebook-border">
+            <h2 className="text-2xl font-handwriting text-notebook-ink">
+              この画像でよろしいですか？
+            </h2>
+            <p className="text-sm text-notebook-ink-light mt-1 font-sans">
+              料理名: {dishName}
+            </p>
+          </div>
+
+          {/* 画像プレビュー */}
+          <div className="relative z-content p-6">
+            {imageUrl ? (
+              <div className="rounded-lg overflow-hidden border-2 border-notebook-border shadow-md">
+                <img
+                  src={imageUrl}
+                  alt={dishName}
+                  className="w-full aspect-video object-cover"
+                />
+              </div>
+            ) : (
+              <div className="rounded-lg border-2 border-dashed border-notebook-border bg-amber-50 p-12 text-center">
+                <p className="text-notebook-ink-light font-sans">
+                  画像が見つかりませんでした
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* ボタンエリア */}
+          <div className="relative z-content p-6 border-t border-notebook-border flex gap-3 justify-end">
+            {imageUrl ? (
+              <>
+                {/* 画像を使う */}
+                <button
+                  onClick={handleUseImage}
+                  className="px-6 py-3 bg-amber-600 text-white rounded-lg font-sans font-medium hover:bg-amber-700 active:scale-95 transition-all duration-200 shadow-md"
+                >
+                  この画像でOK
+                </button>
+
+                {/* 画像なしで作成 */}
+                <button
+                  onClick={handleSkipImage}
+                  className="px-6 py-3 bg-notebook-card border border-notebook-border text-notebook-ink rounded-lg font-sans hover:bg-amber-50 active:scale-95 transition-all duration-200"
+                >
+                  画像なしで作成
+                </button>
+              </>
+            ) : (
+              <>
+                {/* 画像なしで作成（画像がない場合のデフォルトボタン） */}
+                <button
+                  onClick={handleSkipImage}
+                  className="px-6 py-3 bg-amber-600 text-white rounded-lg font-sans font-medium hover:bg-amber-700 active:scale-95 transition-all duration-200 shadow-md"
+                >
+                  画像なしで作成
+                </button>
+
+                {/* キャンセル */}
+                <button
+                  onClick={onClose}
+                  className="px-6 py-3 bg-notebook-card border border-notebook-border text-notebook-ink rounded-lg font-sans hover:bg-amber-50 active:scale-95 transition-all duration-200"
+                >
+                  キャンセル
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/features/recipes/components/ImagePreviewModal.tsx
+++ b/src/features/recipes/components/ImagePreviewModal.tsx
@@ -33,7 +33,7 @@ export function ImagePreviewModal({
     <>
       {/* オーバーレイ */}
       <div
-        className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+        className="fixed inset-0 bg-black/50 z-[100] flex items-center justify-center p-4"
         onClick={onClose}
       >
         {/* モーダルコンテンツ */}
@@ -46,10 +46,10 @@ export function ImagePreviewModal({
 
           {/* ヘッダー */}
           <div className="relative z-content p-6 border-b border-notebook-border">
-            <h2 className="text-2xl font-handwriting text-notebook-ink">
+            <h2 className="text-note-2xl font-handwriting text-notebook-ink">
               この画像でよろしいですか？
             </h2>
-            <p className="text-sm text-notebook-ink-light mt-1 font-sans">
+            <p className="text-note-sm text-notebook-ink-light mt-1 font-sans">
               料理名: {dishName}
             </p>
           </div>
@@ -65,8 +65,8 @@ export function ImagePreviewModal({
                 />
               </div>
             ) : (
-              <div className="rounded-lg border-2 border-dashed border-notebook-border bg-amber-50 p-12 text-center">
-                <p className="text-notebook-ink-light font-sans">
+              <div className="rounded-lg border-2 border-dashed border-notebook-border bg-notebook-accent-light/30 p-12 text-center">
+                <p className="text-note-base text-notebook-ink-light font-sans">
                   画像が見つかりませんでした
                 </p>
               </div>
@@ -80,7 +80,7 @@ export function ImagePreviewModal({
                 {/* 画像を使う */}
                 <button
                   onClick={handleUseImage}
-                  className="px-6 py-3 bg-amber-600 text-white rounded-lg font-sans font-medium hover:bg-amber-700 active:scale-95 transition-all duration-200 shadow-md"
+                  className="px-6 py-3 bg-notebook-accent text-white rounded-lg font-sans font-medium hover:bg-notebook-accent/90 active:scale-95 transition-all duration-200 shadow-md"
                 >
                   この画像でOK
                 </button>
@@ -88,7 +88,7 @@ export function ImagePreviewModal({
                 {/* 画像なしで作成 */}
                 <button
                   onClick={handleSkipImage}
-                  className="px-6 py-3 bg-notebook-card border border-notebook-border text-notebook-ink rounded-lg font-sans hover:bg-amber-50 active:scale-95 transition-all duration-200"
+                  className="px-6 py-3 bg-notebook-card border border-notebook-border text-notebook-ink rounded-lg font-sans hover:bg-notebook-accent-light/20 active:scale-95 transition-all duration-200"
                 >
                   画像なしで作成
                 </button>
@@ -98,7 +98,7 @@ export function ImagePreviewModal({
                 {/* 画像なしで作成（画像がない場合のデフォルトボタン） */}
                 <button
                   onClick={handleSkipImage}
-                  className="px-6 py-3 bg-amber-600 text-white rounded-lg font-sans font-medium hover:bg-amber-700 active:scale-95 transition-all duration-200 shadow-md"
+                  className="px-6 py-3 bg-notebook-accent text-white rounded-lg font-sans font-medium hover:bg-notebook-accent/90 active:scale-95 transition-all duration-200 shadow-md"
                 >
                   画像なしで作成
                 </button>
@@ -106,7 +106,7 @@ export function ImagePreviewModal({
                 {/* キャンセル */}
                 <button
                   onClick={onClose}
-                  className="px-6 py-3 bg-notebook-card border border-notebook-border text-notebook-ink rounded-lg font-sans hover:bg-amber-50 active:scale-95 transition-all duration-200"
+                  className="px-6 py-3 bg-notebook-card border border-notebook-border text-notebook-ink rounded-lg font-sans hover:bg-notebook-accent-light/20 active:scale-95 transition-all duration-200"
                 >
                   キャンセル
                 </button>

--- a/src/features/recipes/components/RecipeCard.tsx
+++ b/src/features/recipes/components/RecipeCard.tsx
@@ -16,36 +16,53 @@ export function RecipeCard({ recipe, onClick, onToggleFavorite }: RecipeCardProp
       <div className="absolute inset-0 bg-paper-texture opacity-30 pointer-events-none z-texture rounded-card" />
 
       {/* 画像エリア */}
-      {(recipe.illustrated_url || recipe.thumbnail_url) && (
-        <div className="relative z-content p-card-padding pb-2">
+      <div className="relative z-content p-card-padding pb-2">
+        {recipe.illustrated_url || recipe.thumbnail_url ? (
           <img
             src={recipe.illustrated_url || recipe.thumbnail_url || ''}
             alt={recipe.title}
             className="rounded-lg w-full aspect-square object-cover"
             loading="lazy"
           />
+        ) : (
+          /* デフォルト画像プレースホルダー（手帳風） */
+          <div className="rounded-lg w-full aspect-square bg-gradient-to-br from-amber-50 to-amber-100 flex items-center justify-center border-2 border-dashed border-amber-300/50">
+            <svg
+              className="w-24 h-24 text-amber-400/40"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"
+              />
+            </svg>
+          </div>
+        )}
 
-          {/* お気に入りボタン */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onToggleFavorite(recipe.id)
-            }}
-            className="absolute top-2 right-2 w-9 h-9 rounded-full bg-white/90 backdrop-blur-sm flex items-center justify-center shadow-md hover:scale-110 active:scale-95 transition-transform duration-200 z-content"
-            aria-label={recipe.favorite ? 'お気に入りから削除' : 'お気に入りに追加'}
-          >
-            {recipe.favorite ? (
-              <svg className="w-5 h-5 fill-red-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path d="M9.653 16.915l-.005-.003-.019-.01a20.759 20.759 0 01-1.162-.682 22.045 22.045 0 01-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 018-2.828A4.5 4.5 0 0118 7.5c0 2.852-2.045 5.233-3.885 6.82a22.049 22.049 0 01-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 01-.69.001z" />
-              </svg>
-            ) : (
-              <svg className="w-5 h-5 stroke-gray-500" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
-              </svg>
-            )}
-          </button>
-        </div>
-      )}
+        {/* お気に入りボタン */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onToggleFavorite(recipe.id)
+          }}
+          className="absolute top-2 right-2 w-9 h-9 rounded-full bg-white/90 backdrop-blur-sm flex items-center justify-center shadow-md hover:scale-110 active:scale-95 transition-transform duration-200 z-content"
+          aria-label={recipe.favorite ? 'お気に入りから削除' : 'お気に入りに追加'}
+        >
+          {recipe.favorite ? (
+            <svg className="w-5 h-5 fill-red-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M9.653 16.915l-.005-.003-.019-.01a20.759 20.759 0 01-1.162-.682 22.045 22.045 0 01-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 018-2.828A4.5 4.5 0 0118 7.5c0 2.852-2.045 5.233-3.885 6.82a22.049 22.049 0 01-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 01-.69.001z" />
+            </svg>
+          ) : (
+            <svg className="w-5 h-5 stroke-gray-500" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+            </svg>
+          )}
+        </button>
+      </div>
 
       {/* コンテンツエリア */}
       <div className="relative z-content px-card-padding pb-card-padding">

--- a/src/features/recipes/components/RecipeCard.tsx
+++ b/src/features/recipes/components/RecipeCard.tsx
@@ -1,4 +1,5 @@
 import { Recipe } from '../types/recipe.types'
+import { RecipePlaceholder } from './RecipePlaceholder'
 
 interface RecipeCardProps {
   recipe: Recipe
@@ -25,22 +26,8 @@ export function RecipeCard({ recipe, onClick, onToggleFavorite }: RecipeCardProp
             loading="lazy"
           />
         ) : (
-          /* デフォルト画像プレースホルダー（手帳風） */
-          <div className="rounded-lg w-full aspect-square bg-gradient-to-br from-amber-50 to-amber-100 flex items-center justify-center border-2 border-dashed border-amber-300/50">
-            <svg
-              className="w-24 h-24 text-amber-400/40"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"
-              />
-            </svg>
-          </div>
+          /* カテゴリ別プレースホルダー（手書き風アイコン） */
+          <RecipePlaceholder category={recipe.category} />
         )}
 
         {/* お気に入りボタン */}

--- a/src/features/recipes/components/RecipeForm.tsx
+++ b/src/features/recipes/components/RecipeForm.tsx
@@ -179,16 +179,20 @@ export function RecipeForm() {
       toast('料理写真を検索しています...', { icon: '🔍' })
 
       try {
-        // 英語の料理名で検索（精度向上のため）
-        const searchQuery = extracted.dishNameEnglish || extracted.dishName || extracted.title
-        console.log('🔍 Unsplash検索:', {
+        // 多段階検索戦略で画像を取得
+        console.log('🔍 Unsplash検索 (多段階戦略):', {
           title: extracted.title,
           dishName: extracted.dishName,
           dishNameEnglish: extracted.dishNameEnglish,
-          searchQuery
+          alternativeEnglishNames: extracted.alternativeEnglishNames,
+          dishCategory: extracted.dishCategory,
         })
 
-        const imageUrl = await unsplashService.getFoodImage(searchQuery)
+        const imageUrl = await unsplashService.getFoodImage({
+          primaryName: extracted.dishNameEnglish || extracted.dishName || extracted.title,
+          alternativeNames: extracted.alternativeEnglishNames || [],
+          category: extracted.dishCategory,
+        })
 
         if (imageUrl) {
           console.log('📸 Unsplash画像取得成功:', imageUrl)

--- a/src/features/recipes/components/RecipeForm.tsx
+++ b/src/features/recipes/components/RecipeForm.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/shared/components/Input'
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/shared/components/Accordion'
 import { ImageUpload } from './ImageUpload'
 import { RecipeScreenshotUpload } from './RecipeScreenshotUpload'
+import { ImagePreviewModal } from './ImagePreviewModal'
 import { imageService } from '../services/imageService'
 import { visionService } from '../services/visionService'
 import { unsplashService } from '../services/unsplashService'
@@ -41,6 +42,12 @@ export function RecipeForm() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isGeneratingTitle, setIsGeneratingTitle] = useState(false)
   const [isLoadingRecipe, setIsLoadingRecipe] = useState(false)
+
+  // 画像プレビューモーダル用
+  const [showImagePreviewModal, setShowImagePreviewModal] = useState(false)
+  const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(null)
+  const [previewDishName, setPreviewDishName] = useState('')
+  const [pendingExtractedData, setPendingExtractedData] = useState<any>(null)
 
   // 編集モード: 既存レシピをロード
   useEffect(() => {
@@ -136,6 +143,71 @@ export function RecipeForm() {
     }
   }
 
+  // 画像プレビューモーダルの確定処理
+  const handleImageConfirm = async (useImage: boolean) => {
+    setShowImagePreviewModal(false)
+
+    if (!pendingExtractedData) {
+      console.warn('⚠️ 保留中の抽出データがありません')
+      return
+    }
+
+    try {
+      // 画像を使用する場合の処理
+      if (useImage && previewImageUrl) {
+        toast('画像を変換しています...', { icon: '🎨' })
+
+        // URLからFileオブジェクトに変換
+        const imageFile = await unsplashService.urlToFile(
+          previewImageUrl,
+          `${pendingExtractedData.dishName || 'recipe'}.jpg`
+        )
+
+        // イラスト風に変換
+        const illustratedFile = await illustrationService.convertToIllustration(imageFile)
+        setSelectedImage(illustratedFile)
+
+        toast.success('画像を設定しました')
+      } else {
+        // 画像を使用しない場合
+        setSelectedImage(null)
+        toast('画像なしで作成します', { icon: 'ℹ️' })
+      }
+
+      // フォームに抽出データを反映（画像選択に関わらず実行）
+      setTitle(pendingExtractedData.title)
+      setServings(pendingExtractedData.servings || '')
+      setIngredients(pendingExtractedData.ingredients)
+      setSteps(pendingExtractedData.steps)
+      setMemo(pendingExtractedData.memo || '')
+
+      // 短縮タイトルを自動生成
+      try {
+        const generated = await visionService.generateDisplayTitle(pendingExtractedData.title)
+        setDisplayTitle(generated)
+      } catch (error) {
+        console.error('短縮タイトル生成エラー:', error)
+        // エラーでも続行（短縮タイトルは任意のため）
+      }
+
+      // レシピ情報セクションにスクロール
+      setTimeout(() => {
+        recipeFormSectionRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        })
+      }, 300)
+    } catch (error) {
+      console.error('❌ 画像変換エラー:', error)
+      toast.error('画像の変換に失敗しました')
+    } finally {
+      // 状態をクリア
+      setPendingExtractedData(null)
+      setPreviewImageUrl(null)
+      setPreviewDishName('')
+    }
+  }
+
   // AI抽出実行
   const handleExtractRecipe = async () => {
     if (screenshots.length === 0) {
@@ -149,33 +221,9 @@ export function RecipeForm() {
       // Vision APIでレシピ情報を抽出
       const extracted = await visionService.extractRecipeFromImages(screenshots)
 
-      // フォームに自動入力
-      setTitle(extracted.title)
-      setServings(extracted.servings || '')
-      setIngredients(extracted.ingredients)
-      setSteps(extracted.steps)
-      setMemo(extracted.memo || '')
-
-      // 短縮タイトルを自動生成
-      try {
-        const generated = await visionService.generateDisplayTitle(extracted.title)
-        setDisplayTitle(generated)
-      } catch (error) {
-        console.error('短縮タイトル生成エラー:', error)
-        // エラーでも続行（短縮タイトルは任意のため）
-      }
-
       toast.success('レシピ情報を抽出しました！')
 
-      // レシピ情報セクションにスクロール
-      setTimeout(() => {
-        recipeFormSectionRef.current?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        })
-      }, 300)
-
-      // 料理写真の処理：常にUnsplashから取得してイラスト風に変換
+      // 料理写真の処理：常にUnsplashから取得してプレビューモーダルで確認
       toast('料理写真を検索しています...', { icon: '🔍' })
 
       try {
@@ -194,31 +242,30 @@ export function RecipeForm() {
           category: extracted.dishCategory,
         })
 
+        // 抽出データを保存（モーダル確定後に使用）
+        setPendingExtractedData(extracted)
+        setPreviewImageUrl(imageUrl)
+        setPreviewDishName(extracted.dishName || extracted.title)
+
+        // 画像プレビューモーダルを表示
+        setShowImagePreviewModal(true)
+
         if (imageUrl) {
           console.log('📸 Unsplash画像取得成功:', imageUrl)
-
-          // URLからFileオブジェクトに変換
-          const imageFile = await unsplashService.urlToFile(
-            imageUrl,
-            `${extracted.dishName}_original.jpg`
-          )
-          console.log('📦 Fileオブジェクト変換完了:', imageFile.name, imageFile.size)
-
-          // イラスト風に変換（強度3: 強め）
-          console.log('🎨 イラスト風変換開始...')
-          const illustratedFile = await illustrationService.convertToIllustration(imageFile, 3)
-          console.log('✨ イラスト風変換完了:', illustratedFile.name, illustratedFile.size)
-
-          setSelectedImage(illustratedFile)
-
-          toast.success('料理写真を取得しました')
+          toast.success('画像を確認してください')
         } else {
           console.warn('⚠️ Unsplash画像が見つかりませんでした')
-          toast('料理写真が見つかりませんでした。後で手動で追加できます。', { icon: 'ℹ️' })
+          toast('画像が見つかりませんでした', { icon: 'ℹ️' })
         }
       } catch (imageError) {
         console.error('❌ 画像取得エラー:', imageError)
-        toast('料理写真の取得に失敗しました。後で手動で追加できます。', { icon: 'ℹ️' })
+        toast('料理写真の取得に失敗しました', { icon: 'ℹ️' })
+
+        // エラーの場合もモーダルを表示（画像なしで作成可能）
+        setPendingExtractedData(extracted)
+        setPreviewImageUrl(null)
+        setPreviewDishName(extracted.dishName || extracted.title)
+        setShowImagePreviewModal(true)
       }
     } catch (error) {
       console.error('レシピ抽出エラー:', error)
@@ -592,6 +639,15 @@ export function RecipeForm() {
           </Accordion>
         </div>
       </div>
+
+      {/* 画像プレビューモーダル */}
+      <ImagePreviewModal
+        isOpen={showImagePreviewModal}
+        imageUrl={previewImageUrl}
+        dishName={previewDishName}
+        onConfirm={handleImageConfirm}
+        onClose={() => setShowImagePreviewModal(false)}
+      />
     </div>
   )
 }

--- a/src/features/recipes/components/RecipePlaceholder.tsx
+++ b/src/features/recipes/components/RecipePlaceholder.tsx
@@ -1,0 +1,343 @@
+interface RecipePlaceholderProps {
+  category?: string | null
+}
+
+/**
+ * レシピ画像のプレースホルダーコンポーネント
+ * カテゴリに応じた手書き風アイコンを表示
+ */
+export function RecipePlaceholder({ category }: RecipePlaceholderProps) {
+  // カテゴリに応じたアイコンとカラーを取得
+  const getIconConfig = () => {
+    switch (category) {
+      case 'rice dish':
+        return {
+          icon: <RiceDishIcon />,
+          bgColor: 'from-amber-50 to-orange-50',
+          borderColor: 'border-amber-300/50',
+          label: 'ご飯',
+        }
+      case 'noodle dish':
+        return {
+          icon: <NoodleDishIcon />,
+          bgColor: 'from-yellow-50 to-amber-50',
+          borderColor: 'border-yellow-300/50',
+          label: '麺類',
+        }
+      case 'soup':
+        return {
+          icon: <SoupIcon />,
+          bgColor: 'from-orange-50 to-red-50',
+          borderColor: 'border-orange-300/50',
+          label: 'スープ',
+        }
+      case 'salad':
+        return {
+          icon: <SaladIcon />,
+          bgColor: 'from-green-50 to-emerald-50',
+          borderColor: 'border-green-300/50',
+          label: 'サラダ',
+        }
+      case 'dessert':
+        return {
+          icon: <DessertIcon />,
+          bgColor: 'from-pink-50 to-rose-50',
+          borderColor: 'border-pink-300/50',
+          label: 'デザート',
+        }
+      default:
+        return {
+          icon: <DefaultFoodIcon />,
+          bgColor: 'from-amber-50 to-amber-100',
+          borderColor: 'border-amber-300/50',
+          label: '料理',
+        }
+    }
+  }
+
+  const { icon, bgColor, borderColor, label } = getIconConfig()
+
+  return (
+    <div
+      className={`rounded-lg w-full aspect-square bg-gradient-to-br ${bgColor} flex flex-col items-center justify-center border-2 border-dashed ${borderColor}`}
+    >
+      {/* アイコン */}
+      <div className="mb-2">{icon}</div>
+      {/* カテゴリラベル（手書き風フォント） */}
+      <p className="text-xs font-handwriting text-amber-600/60">{label}</p>
+    </div>
+  )
+}
+
+/**
+ * ご飯系の手書き風アイコン
+ */
+function RiceDishIcon() {
+  return (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* 茶碗（手書き風の歪んだ曲線） */}
+      <path
+        d="M 20 35 Q 18 38 18 42 Q 18 50 22 55 Q 26 60 32 62 Q 38 64 40 64 Q 42 64 48 62 Q 54 60 58 55 Q 62 50 62 42 Q 62 38 60 35"
+        stroke="#d97706"
+        strokeWidth="2.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+      {/* 茶碗の上部の楕円（手書き風） */}
+      <ellipse
+        cx="40"
+        cy="35"
+        rx="21"
+        ry="6"
+        stroke="#d97706"
+        strokeWidth="2.5"
+        fill="#fef3c7"
+        opacity="0.6"
+      />
+      {/* ご飯粒（小さな丸）手書き風に少し歪ませる */}
+      <circle cx="35" cy="32" r="2" fill="#d97706" opacity="0.4" />
+      <circle cx="42" cy="30" r="2.5" fill="#d97706" opacity="0.4" />
+      <circle cx="38" cy="28" r="2" fill="#d97706" opacity="0.4" />
+      <circle cx="44" cy="33" r="2" fill="#d97706" opacity="0.4" />
+      <circle cx="40" cy="25" r="2.5" fill="#d97706" opacity="0.4" />
+    </svg>
+  )
+}
+
+/**
+ * 麺類の手書き風アイコン
+ */
+function NoodleDishIcon() {
+  return (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* 丼（手書き風の歪んだ曲線） */}
+      <path
+        d="M 22 38 Q 20 42 20 46 Q 20 52 24 56 Q 28 60 34 62 Q 38 63 40 63 Q 42 63 46 62 Q 52 60 56 56 Q 60 52 60 46 Q 60 42 58 38"
+        stroke="#ca8a04"
+        strokeWidth="2.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+      {/* 丼の上部の楕円 */}
+      <ellipse
+        cx="40"
+        cy="38"
+        rx="19"
+        ry="5"
+        stroke="#ca8a04"
+        strokeWidth="2.5"
+        fill="#fef9c3"
+        opacity="0.5"
+      />
+      {/* 麺（手書き風のうねった線） */}
+      <path
+        d="M 28 35 Q 30 28 32 25 Q 34 22 36 24"
+        stroke="#ca8a04"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+      <path
+        d="M 38 36 Q 40 30 42 26 Q 43 23 45 25"
+        stroke="#ca8a04"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+      <path
+        d="M 46 35 Q 48 29 50 26 Q 51 24 52 26"
+        stroke="#ca8a04"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+    </svg>
+  )
+}
+
+/**
+ * スープの手書き風アイコン
+ */
+function SoupIcon() {
+  return (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* カップ */}
+      <path
+        d="M 25 40 Q 24 44 24 48 Q 24 54 28 58 Q 32 62 38 63 Q 42 64 44 63 Q 50 62 54 58 Q 58 54 58 48 Q 58 44 57 40"
+        stroke="#ea580c"
+        strokeWidth="2.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+      <ellipse
+        cx="41"
+        cy="40"
+        rx="17"
+        ry="5"
+        stroke="#ea580c"
+        strokeWidth="2.5"
+        fill="#fed7aa"
+        opacity="0.5"
+      />
+      {/* 湯気（手書き風のうねり） */}
+      <path
+        d="M 32 32 Q 30 28 32 24"
+        stroke="#ea580c"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        opacity="0.4"
+      />
+      <path
+        d="M 41 30 Q 39 26 41 22"
+        stroke="#ea580c"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        opacity="0.4"
+      />
+      <path
+        d="M 50 32 Q 52 28 50 24"
+        stroke="#ea580c"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        opacity="0.4"
+      />
+    </svg>
+  )
+}
+
+/**
+ * サラダの手書き風アイコン
+ */
+function SaladIcon() {
+  return (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* ボウル */}
+      <path
+        d="M 22 42 Q 20 46 20 50 Q 20 56 24 60 Q 28 64 34 65 Q 38 66 40 66 Q 42 66 46 65 Q 52 64 56 60 Q 60 56 60 50 Q 60 46 58 42"
+        stroke="#16a34a"
+        strokeWidth="2.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+      <ellipse
+        cx="40"
+        cy="42"
+        rx="19"
+        ry="5"
+        stroke="#16a34a"
+        strokeWidth="2.5"
+        fill="#d1fae5"
+        opacity="0.5"
+      />
+      {/* 葉っぱ（手書き風） */}
+      <ellipse
+        cx="32"
+        cy="35"
+        rx="6"
+        ry="10"
+        fill="#16a34a"
+        opacity="0.3"
+        transform="rotate(-20 32 35)"
+      />
+      <ellipse
+        cx="40"
+        cy="32"
+        rx="6"
+        ry="11"
+        fill="#16a34a"
+        opacity="0.3"
+      />
+      <ellipse
+        cx="48"
+        cy="35"
+        rx="6"
+        ry="10"
+        fill="#16a34a"
+        opacity="0.3"
+        transform="rotate(20 48 35)"
+      />
+    </svg>
+  )
+}
+
+/**
+ * デザートの手書き風アイコン
+ */
+function DessertIcon() {
+  return (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* ケーキの土台（台形） */}
+      <path
+        d="M 28 55 L 24 65 L 56 65 L 52 55 Z"
+        fill="#fce7f3"
+        stroke="#ec4899"
+        strokeWidth="2"
+        opacity="0.6"
+      />
+      {/* ケーキの中段 */}
+      <path
+        d="M 30 45 L 28 55 L 52 55 L 50 45 Z"
+        fill="#fbcfe8"
+        stroke="#ec4899"
+        strokeWidth="2"
+        opacity="0.6"
+      />
+      {/* ケーキの上段 */}
+      <path
+        d="M 34 35 L 32 45 L 48 45 L 46 35 Z"
+        fill="#f9a8d4"
+        stroke="#ec4899"
+        strokeWidth="2"
+        opacity="0.6"
+      />
+      {/* ろうそく */}
+      <line
+        x1="40"
+        y1="35"
+        x2="40"
+        y2="25"
+        stroke="#ec4899"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      {/* 炎 */}
+      <ellipse
+        cx="40"
+        cy="22"
+        rx="3"
+        ry="5"
+        fill="#fb923c"
+        opacity="0.6"
+      />
+    </svg>
+  )
+}
+
+/**
+ * デフォルトの料理アイコン（フォークとナイフ）
+ */
+function DefaultFoodIcon() {
+  return (
+    <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* フォーク（左側） */}
+      <line x1="28" y1="25" x2="28" y2="60" stroke="#d97706" strokeWidth="2.5" strokeLinecap="round" />
+      <line x1="24" y1="25" x2="24" y2="38" stroke="#d97706" strokeWidth="2" strokeLinecap="round" />
+      <line x1="32" y1="25" x2="32" y2="38" stroke="#d97706" strokeWidth="2" strokeLinecap="round" />
+      <path d="M 24 38 Q 26 40 28 40 Q 30 40 32 38" stroke="#d97706" strokeWidth="2" fill="none" />
+
+      {/* ナイフ（右側） */}
+      <line x1="52" y1="25" x2="52" y2="60" stroke="#d97706" strokeWidth="2.5" strokeLinecap="round" />
+      <path
+        d="M 48 25 L 52 25 L 54 28 L 54 35 L 52 38 L 48 38 Z"
+        fill="#d97706"
+        opacity="0.4"
+      />
+    </svg>
+  )
+}

--- a/src/features/recipes/services/unsplashService.ts
+++ b/src/features/recipes/services/unsplashService.ts
@@ -104,20 +104,21 @@ class UnsplashService {
         }
       }
 
-      // Step 3: カテゴリ検索
-      if (category) {
-        console.log(`\n🔍 [Step 3] カテゴリ検索: "${category}"`)
-        const categoryPhotos = await this.searchPhotos(category)
+      // Step 3: カテゴリ検索（無効化：精度が低いため）
+      // Issue #3でユーザー選択機能を実装するまで無効化
+      // if (category) {
+      //   console.log(`\n🔍 [Step 3] カテゴリ検索: "${category}"`)
+      //   const categoryPhotos = await this.searchPhotos(category)
 
-        if (categoryPhotos.length > 0) {
-          const bestPhoto = this.selectBestPhoto(categoryPhotos, category, this.SCORE_THRESHOLDS.category)
+      //   if (categoryPhotos.length > 0) {
+      //     const bestPhoto = this.selectBestPhoto(categoryPhotos, category, this.SCORE_THRESHOLDS.category)
 
-          if (bestPhoto) {
-            console.log(`✅ カテゴリ検索で発見: ${bestPhoto.alt_description || 'No description'}`)
-            return bestPhoto.urls.regular
-          }
-        }
-      }
+      //     if (bestPhoto) {
+      //       console.log(`✅ カテゴリ検索で発見: ${bestPhoto.alt_description || 'No description'}`)
+      //       return bestPhoto.urls.regular
+      //     }
+      //   }
+      // }
 
       console.warn('❌ すべての検索で適切な画像が見つかりませんでした')
       return null


### PR DESCRIPTION
## Summary

レシピ一覧で画像が表示されないレシピに対する修正と、画像プレビュー機能を実装しました。

### 変更内容

#### 1. **多段階フォールバック検索の有効化** (`RecipeForm.tsx`)
- 既存の`unsplashService.getFoodImage()`の多段階検索機能を活用
- パラメータオブジェクトを渡すように変更:
  - `primaryName`: メイン料理名（例: "omurice"）
  - `alternativeNames`: 代替英語名（例: ["omelet rice", "ketchup rice"]）
  - `category`: 料理カテゴリ（例: "rice dish"） ※現在は無効化
- これにより、画像が見つかる確率が大幅に向上

#### 2. **カテゴリ検索の無効化** (`unsplashService.ts`)
- カテゴリベースの検索（Step 3）は精度が低いため一時的に無効化
- より正確な画像マッチングを優先
- Issue #3で画像選択機能実装後に再評価

#### 3. **手書き風カテゴリアイコンの追加** (`RecipePlaceholder.tsx`)
- 画像がないレシピに対してカテゴリ別のプレースホルダーを表示
- 6種類のカテゴリアイコン（ご飯、麺類、スープ、サラダ、デザート、その他）
- 手帳風のデザインで統一感を実現

#### 4. **画像プレビューモーダルの実装** (Issue #3 Phase 1)
- `ImagePreviewModal.tsx`: 新規コンポーネント作成
  - Unsplash画像のプレビュー表示
  - 「この画像でOK」「画像なしで作成」ボタン
  - 手書き風UIデザイン（ノートブック風）
- `RecipeForm.tsx`: モーダル統合
  - 新フロー: AI抽出 → Unsplash検索 → モーダル表示 → ユーザー確認 → フォーム反映
  - 画像変換（URL→File→イラスト風）はユーザー確認後に実行
  - ユーザーが画像を拒否した場合、手書き風アイコンで作成

### 技術的な実装の特徴

✅ **体系的な設計**
- 既存のサービス層（`unsplashService.ts`）の設計パターンを踏襲
- 関心の分離: 画像取得ロジックとUI表示を明確に分離
- DRY原則: フォールバック検索ロジックを1箇所に集約
- Phase 1のみ実装（Phase 2の複数候補選択、Phase 3の手動アップロードは未実装）

✅ **拡張性**
- 将来的に検索戦略を変更しやすい構造
- モーダルコンポーネントは独立しており、Phase 2/3への拡張が容易
- テスト可能な設計

✅ **ユーザー体験の向上**
- レシピ一覧の視覚的統一感を実現
- ユーザーが画像の適切性を判断できる
- アルバム・スクラップブックのような「ワクワク感」を演出

## Test plan

- [x] TypeScriptビルドが成功することを確認
- [ ] 新規レシピ作成時に多段階検索が実行されることを確認
- [ ] 画像プレビューモーダルが表示されることを確認
- [ ] 「この画像でOK」ボタンで画像が設定されることを確認
- [ ] 「画像なしで作成」ボタンで手書き風アイコンが表示されることを確認
- [ ] 既存レシピの表示に影響がないことを確認
- [ ] レスポンシブデザインが維持されていることを確認

Fixes #1
Implements #3 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)